### PR TITLE
Klonoa_LV: Remove type parameter when loading file from BIN

### DIFF
--- a/src/BinaryDataExplorer/DataManagers/Klonoa/Klonoa_LV_DataManager.cs
+++ b/src/BinaryDataExplorer/DataManagers/Klonoa/Klonoa_LV_DataManager.cs
@@ -87,7 +87,7 @@ namespace BinaryDataExplorer
                 BaseFile fileData;
 
                 if (bin == Loader_LV.BINType.KL)
-                    fileData = await Task.Run(() => loader.LoadBINFile<LevelPack_ArchiveFile>(bin, fileIndex));
+                    fileData = await Task.Run(() => loader.LoadBINFile(bin, fileIndex, languageIndex: languageIndex));
                 else
                     fileData = await Task.Run(() => loader.LoadBINFile<RawData_File>(bin, fileIndex));
 


### PR DESCRIPTION
The function in https://github.com/RayCarrot/BinarySerializer.Klonoa/commit/f7e126852c6511e110d310bbc0f0dbed5a7f1db5 returns the proper archive type, so the type parameter is no longer needed.